### PR TITLE
FIXED WRONG NAMING IN README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Which, produces the following output:
 
 <img src="images/data_head.png" alt="Description" width="1000" height="175">
 
-The data frame above is indexed by Ensemble gene ID (ENSG), and then there are six columns of RNA-sequencing expression data (i.e., counts). The first three columns contain expression counts for the control group, and the last three columns contain expression counts for the experimental group (i.e., the amiloride treatment group). Note that both groups use the JJN3 cell line, which was established from the bone marrow of a 57-year-old woman with plasma cell leukemia.
+The data frame above is indexed by Ensemble gene ID (ENSG), and then there are six columns of RNA-sequencing expression data (i.e., counts). The first three columns contain expression counts for the experimental group (i.e., the amiloride treatment group), and the last three columns contain expression counts for the control group. Note that both groups use the JJN3 cell line, which was established from the bone marrow of a 57-year-old woman with plasma cell leukemia.
 
 Next, we'll want to perform preliminary data analysis to understand the distribution and variability of RNA sequencing counts across the samples and check for missing data before performing any downstream analysis. First, let's check out our sample quality:
 


### PR DESCRIPTION
experimental group and control group were switched in the original readme. In fact the first 3 rows refer to the group treated with amelioride and not to the control group.